### PR TITLE
Use official GitHub name

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@
   <footer class="text-center text-muted mb-3">
     <p>&hellip;</p>
     <small>Built with <a href="https://github.com/vuejs/vue-cli">vue-cli</a> &centerdot; Checkout source on <a
-            href="https://github.com/vuejs/vue-issue">Github</a></small>
+            href="https://github.com/vuejs/vue-issue">GitHub</a></small>
   </footer>
 </div>
 </template>

--- a/src/Header.vue
+++ b/src/Header.vue
@@ -6,7 +6,7 @@
 
       <ul class="navbar-nav ml-auto d-flex flex-row">
         <li class="nav-item px-2">
-          <a class="nav-link ml-auto" :href="`https://github.com/${repo}/issues`" target="_blank">Github</a>
+          <a class="nav-link ml-auto" :href="`https://github.com/${repo}/issues`" target="_blank">GitHub</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
It's `GitHub`, not `Github` (yeah, I'm sorry…)